### PR TITLE
250909_채_메뉴 수량 state 위치 수정

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -25,6 +25,18 @@ function App() {
     console.log(menuQty);
   }, [menuQty]);
 
+  const onSelectMenu = (id, qty) => {
+    setMenuQty(prev => {
+      if (qty === 0) return prev.filter(item => item.id !== id);
+      const exists = prev.find(item => item.id === id);
+      if (exists) {
+        return prev.map(item => item.id === id ? { ...item, qty } : item);
+      } else {
+        return [...prev, { id, qty }];
+      }
+    });
+  };
+
   return (
     <div className="App">
       <header>
@@ -38,22 +50,8 @@ function App() {
       />
       <Menu 
         menuData={menu}
-        onSelectMenu={(id, qty)=>{
-          setMenuQty((prevItems) => {
-            // 기존에 동일 id가 있으면 덮어쓰기, 없으면 새로 추가
-            const exists = prevItems.find(item => item.id === id);
-            if (exists) {
-              if(qty === 0){
-                return prevItems.filter(item => item.id !== id);
-              }
-              return prevItems.map(item =>
-                item.id === id ? { ...item, qty } : item
-              );
-            } else {
-              return [...prevItems, { id, qty }];
-            }
-          });
-        }}
+        menuQty={menuQty}
+        onSelectMenu={onSelectMenu}
       />
     </div>
   );

--- a/front/src/Comp/Menu.js
+++ b/front/src/Comp/Menu.js
@@ -1,7 +1,14 @@
 import React from 'react'
 import QtyBtn from './QtyBtn'
 
+/**props : menuData(parsing된 메뉴), menyQty(메뉴고유아이디, 수량), onSelectMenu(수량 업데이트 함수) */
 const Menu = (props) => {
+    /**해당 메뉴의 수량을 읽어옴 (수량 변화가 없었다면 0 return) */
+    const getQty = (id) => {
+        const found = props.menuQty.find(item => item.id === id);
+        return found ? found.qty : 0;
+    };
+
     let menuList
     if(props.menuData == null){
         menuList = 'loading...'
@@ -13,6 +20,7 @@ const Menu = (props) => {
                         {data.name}
                         <QtyBtn 
                             menuId={data.id}
+                            qty={getQty(data.id)}
                             onSelectMenu={props.onSelectMenu}
                         />
                     </li>
@@ -30,6 +38,7 @@ const Menu = (props) => {
                     <img src={data.image}></img>
                     <QtyBtn 
                         menuId={data.id}
+                        qty={getQty(data.id)}
                         onSelectMenu={props.onSelectMenu}
                     />
                 </li>

--- a/front/src/Comp/QtyBtn.js
+++ b/front/src/Comp/QtyBtn.js
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import '../styles/qtyBtn.css'
 
+/**props: menuId(해당 메뉴의 고유아이디), qty(해당 메뉴를 담은 수량), onSelectMenu(수량 업데이트 함수) */
 const QtyBtn = (props) => {
     const [active, setActive] = useState(false);
-    const [qty, setQty] = useState(0);
 
+    /**수량 버튼 activate 시키는 역할, 
+     * 버튼과 상호작용 있을 시 타이머 초기화, 5초 이상 상호작용 없을 시 원으로 돌아감 */
     useEffect(()=>{
         if (!active) return;
 
@@ -13,34 +15,27 @@ const QtyBtn = (props) => {
         }, 5000);
 
         return () => clearTimeout(timer);
-    }, [qty, active]);
-
-    useEffect(()=>{
-        if(qty >= 0){
-            props.onSelectMenu(props.menuId, qty);
-        }
-    }, [qty, props.menuId]);
+    }, [active]);
 
     let btn;
-    if(!active && qty === 0){
+    if(!active && props.qty === 0){
         btn = <div className="plus-shape"></div>
     }
-    else if(!active && qty > 0){
-        btn = <div className="btn-inactive qty">{qty}</div>
+    else if(!active && props.qty > 0){
+        btn = <div className="btn-inactive qty">{props.qty}</div>
     }
     else if(active){
-        
         btn = <div className="qty-controls">
-                <div onClick={() => setQty(q => Math.max(0, q - 1))}>-</div>
-                <span>{qty}</span>
-                <div onClick={() => setQty(q => q + 1)}>+</div>
+                <div onClick={() => props.onSelectMenu(props.menuId, Math.max(0, props.qty - 1))}>-</div>
+                <span>{props.qty}</span>
+                <div onClick={() => props.onSelectMenu(props.menuId, props.qty + 1)}>+</div>
               </div>
     }
     
 
     return (
         <div
-            key={props.key}
+            key={props.menuId}
             className={active === false ? 'btn-inactive' : 'btn-active'}
             onClick={(e)=>{
                 setActive(true);                


### PR DESCRIPTION
메뉴 수량 세는 상태 변수가 App.js에 없고 하위 컴포넌트에 있어 탭1 -> 탭2 -> 탭1 과 같이 이동하면 담은 수량이 모두 날라가는 결함 발생. (탭 이동 때마다 메뉴를 parsing 하기 때문에 다시 돌아갈 경우 초기화되었던 것)
하여 하위 컴포넌트에 있던 qty를 삭제하고, App.js에 앞서 선언해두었던 menuQty를 이용하여 하위 컴포넌트로 전달해 수량 계산하는 방식으로 수정함.