### PR TITLE
250910_채_cart 페이지에서 담은 수량만큼 list up

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -9,6 +9,7 @@ function App() {
   const [activated, setActivated] = useState('main');
   const [menu, setMenu] = useState(null);
   const [menuQty, setMenuQty] = useState([]);
+  const [receipt, setReceipt] = useState([]);
 
   /*menu.json 불러오는 비동기함수, 첫 렌더링에만 실행 */
   useEffect(()=>{
@@ -30,9 +31,10 @@ function App() {
   }, [menuQty]);
 
   /*메뉴 id와 수량을 매개변수로 받음. 
-    1. 이전에 수량 변화가 있었던 메뉴면 기존 인덱스에 qty 새 값 덮어씌움
-    2. 이전에 수량 변화가 없었던 메뉴면 새로 인덱스 생성
-    3. 수량을 0으로 만들면 해당 id 가진 인덱스 삭제 */
+    1. 수량을 0으로 만들면 해당 id 가진 인덱스 삭제
+    2. 이전에 수량 변화가 있었던 메뉴면 기존 인덱스에 qty 새 값 덮어씌움
+    3. 이전에 수량 변화가 없었던 메뉴면 새로 인덱스 생성
+     */
   const onSelectMenu = (id, qty) => {
     setMenuQty(prev => {
       if (qty === 0) return prev.filter(item => item.id !== id);
@@ -67,13 +69,16 @@ function App() {
             menuData={menu}
             menuQty={menuQty}
             onSelectMenu={onSelectMenu}
-            currentState={menuQty}
           />
         } />
         <Route path='/aehanmute/cart/id' element={
           <CartPage 
             navUsedAt={(page)=>{ setPage(page); }}
             navState={page}
+            menuQty={menuQty}
+            onSelectMenu={onSelectMenu}
+            receipt={receipt}
+            onDecideMenu={(receipt)=>{ setReceipt(receipt); }}
           />
         } />
       </Routes>

--- a/front/src/Comp/List.js
+++ b/front/src/Comp/List.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import QtyBtn from './QtyBtn';
+
+const List = (props) => {
+  /**해당 메뉴의 수량을 읽어옴 (수량 변화가 없었다면 0 return) */
+  const getQty = (id) => {
+      const found = props.receipt.find(item => item.id === id);
+      return found ? found.qty : 0;
+  };
+
+  return (
+    <>
+      {
+        props.receipt.map(item => (
+          <div key={item.id}>
+            <span>{item.name}</span>
+            <QtyBtn 
+              menuId={item.id}
+              qty={getQty(item.id)}
+              onSelectMenu={props.onSelectMenu}
+            />
+            <span>{item.price === undefined ? '' : `${item.price * item.qty}원`}</span>
+          </div>
+        ))
+      }
+    </>
+  )
+}
+
+export default List

--- a/front/src/Handler/menuLoader.js
+++ b/front/src/Handler/menuLoader.js
@@ -1,4 +1,5 @@
 let menuData = null;
+let menuSet = [];
 
 export const loadMenu = async ()=>{
     if(menuData) return menuData;
@@ -19,4 +20,14 @@ export const getActivatedMenuList = (id)=>{
     if(!menuData) return null;
 
     return menuData.categories.find((categories) => categories.id === id);
+}
+
+export const getAllMenuList = ()=>{
+    if(!menuData) return null;
+
+    menuSet = menuData.categories.flatMap(cat =>
+        cat.items.map(({id, name, price})=>({id, name, price}))
+    );
+    // console.log(menuSet);
+    return menuSet;
 }

--- a/front/src/Pages/CartPage.js
+++ b/front/src/Pages/CartPage.js
@@ -1,12 +1,52 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import Nav from '../Comp/Nav'
+import { getAllMenuList, loadMenu } from '../Handler/menuLoader';
+import List from '../Comp/List';
 
+/**props: nav상태관리, menuQty(id, qty만 들어있음), 
+ *        onSelectMenu(QtyBtn에 id와 수량과 함께 보낼 것),
+ *        reciept(최종 데이터),
+ *        onDecideMenu(최종 주문서 설정, setReceipt() 들어있음) */
 const CartPage = (props) => {
-  props.navUsedAt('cart');
+  const [menu, setMenu] = useState([]);
+  useEffect(()=>{
+    props.navUsedAt('cart');  //cart로 nav 상태 변경
+
+    //최종 주문 데이터(서버 전송) 추출을 위해 메뉴 set 가져오기
+    const initMenu = async ()=>{
+      await loadMenu();
+      setMenu(getAllMenuList());
+    }
+    initMenu();
+  }, []);
+  console.log(menu); //전체 메뉴
+  console.log(props.menuQty);
+
+  //전체 menu set과 client가 담은 특정 메뉴의 수량 set을 합침 => 최종 데이터
+  const menuMap = Object.fromEntries(
+    menu.map(item => [item.id, item])
+  );
+
+  const receipt = props.menuQty.map(({ id, qty }) => ({
+        ...menuMap[id],
+        qty
+  }));
+  console.log(receipt);
+
+  // useEffect(()=>{
+  //   props.onDecideMenu(receipt);
+  //   console.log(receipt);
+  // }, [props.menuQty]);
+
+
   return (
     <>
       <Nav 
         navState={props.navState}
+      />
+      <List 
+        receipt={receipt}
+        onSelectMenu={props.onSelectMenu}
       />
     </>
   )

--- a/front/src/Pages/MenuPage.js
+++ b/front/src/Pages/MenuPage.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import Nav from '../Comp/Nav'
 import Menu from '../Comp/Menu'
 import OrderBtn from '../Comp/OrderBtn'
@@ -6,7 +6,10 @@ import { useNavigate } from 'react-router-dom'
 
 const MenuPage = (props) => {
     const navigate = useNavigate();
-    props.navUsedAt('menu');
+    useEffect(()=>{
+        props.navUsedAt('menu');
+        console.log('nav changed to menu'); //working well
+    }, []);
     return (
         <>
             <Nav 
@@ -20,7 +23,7 @@ const MenuPage = (props) => {
                 onSelectMenu={props.onSelectMenu}
             />
             <OrderBtn
-                currentState={props.currentState}
+                currentState={props.menuQty}
                 onClick={()=> navigate('/aehanmute/cart/id')}
             />
         </>


### PR DESCRIPTION
`cart 페이지로 이동 시, 이전에 담은 메뉴들에 대한 수량도 같이 넘어오게 작성

`cart 페이지에서 수량 변경 있을 시 App.js에 저장된 데이터에도 영향 가게끔 작성